### PR TITLE
Create skeleton for README.dev.md

### DIFF
--- a/README.dev.md
+++ b/README.dev.md
@@ -1,0 +1,46 @@
+# Developer documentation
+
+If you're looking for user documentation, go [here](README.md).
+
+## Development install
+
+### Get your own copy of the repository
+
+Before you can do development work on the template, you'll need to check out a local copy of the repository:
+
+```shell
+cd <where you keep your GitHub repositories>
+git clone https://github.com/nlesc-recruit/CUDA-wrappers.git
+cd CUDA-wrappers
+```
+
+### Prepare your environment
+
+:construction: See issues #7, #31, #32
+
+## Building
+
+:construction: See issue #33
+
+## Running the tests
+
+:construction:
+
+## Building the documentation
+
+:construction: See issue #29
+
+## Making a release
+
+:construction: See issue #30
+
+### Preparation
+
+1. Make sure the `CHANGELOG.md` has been updated
+1. Verify that the information in `CITATION.cff` is correct
+1. Make sure that the `version` in [CITATION.cff](CITATION.cff) have been bumped to the to-be-released version of the template
+
+### GitHub
+
+1. Make sure that the GitHub-Zenodo integration is enabled for https://github.com/nlesc-recruit/CUDA-wrappers
+1. Go to https://github.com/nlesc-recruit/CUDA-wrappers/releases and click `Draft a new release`


### PR DESCRIPTION
**Description**

Creates a skeleton for README.dev.md so we can work on developer documentation separately, and on demand.

**Related issues**:

- #7
- #29 
- #30 
- #31 
- #32 
- #33

**Instructions to review the pull request**

<!--
Clone and verify
```
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/CUDA-wrappers .
git checkout <this-branch>
```
-->

Review online.
