### PR TITLE
fix CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,26 +1,17 @@
 cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
 
-#these two lines work miracles to make CMake use the compilers you also use
-find_program(CMAKE_C_COMPILER NAMES $ENV{CC} gcc PATHS ENV PATH NO_DEFAULT_PATH)
-find_program(CMAKE_CXX_COMPILER NAMES $ENV{CXX} g++ PATHS ENV PATH NO_DEFAULT_PATH)
-
-
-PROJECT(CUDA-Wrappers
-    DESCRIPTION "C++ Wrappers for the CUDA Driver API and related tools"
-    VERSION 0.0.1
-    HOMEPAGE_URL https://github.com/nlesc-recruit/CUDA-wrappers
+project(cudawrappers
+    DESCRIPTION "C++ Wrappers for the CUDA Driver API"
+    VERSION 0.2.0
+    HOMEPAGE_URL https://github.com/nlesc-recruit/cudawrappers
     LANGUAGES CUDA CXX)
-
-
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_BUILD_TYPE "Release")
 
 find_package(CUDAToolkit REQUIRED)
 
+set(SOURCE_FILES src/cu.cpp src/nvrtc.cpp)
+include_directories(./include/)
+include_directories(${CUDAToolkit_INCLUDE_DIRS})
 
-set(CMAKE_CXX_STANDARD 11)
-
-set(SOURCE_FILES cu/cu.cc cu/nvrtc.cc)
-include_directories(.)
-
-add_library(cu SHARED ${SOURCE_FILES})
-
+add_library(cudawrappers SHARED ${SOURCE_FILES})

--- a/src/cu.cpp
+++ b/src/cu.cpp
@@ -1,4 +1,4 @@
-#include "cu/cu.h"
+#include "cu.hpp"
 
 #include <iostream>
 #include <sstream>

--- a/src/nvrtc.cpp
+++ b/src/nvrtc.cpp
@@ -1,4 +1,4 @@
-#include "cu/nvrtc.h"
+#include "nvrtc.hpp"
 
 
 namespace nvrtc {


### PR DESCRIPTION
**Description**

This PR adapts the build system so that it works with the new folder layout.

**Related issues**:
- #50

**Instructions to review the pull request**

Clone and verify

```shell
cd $(mktemp -d --tmpdir cudawrappers-XXXXXX)
git clone https://github.com/nlesc-recruit/CUDA-wrappers .
git checkout 50-fix-cmake
```


## Dependencies for Arch Linux

Install CUDA toolkit

```shell
sudo pacman -S cuda cuda-tools
export PATH=$PATH:/opt/cuda/bin
```

## Build the code

```shell
mkdir build && cd build
cmake ..
```

**Note:** If there are issues with environment variables during cmake, run:

```shell
export CUDAToolkit_ROOT=/opt/cuda
export CUDACXX=/opt/cuda/bin/nvcc
```

If you want to use a different version of C or CXX compiler use or combine

```shell
cmake -DCMAKE_CXX_COMPILER=/path/to/g++ .. 
cmake -DCMAKE_C_COMPILER=/path/to/gcc .. 
cmake -DCMAKE_CUDA_COMPILER=/path/to/nvcc .. 
```
