### PR TITLE
Added more specific conditions to workflow trigger

### DIFF
--- a/.github/workflows/fair-software.yml
+++ b/.github/workflows/fair-software.yml
@@ -1,6 +1,12 @@
 name: fair-software
 
-on: push
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - README.md
+  workflow_dispatch:
 
 jobs:
   verify:


### PR DESCRIPTION
**Description**

This PR adds more specific conditions to the fair-software.nl workflow trigger. After merge it will only trigger the fair-software.nl workflow on pushing changes to main branch when the push affected README.md. Additionally, the PR also adds a manual trigger (`workflow_dispatch`).

**Related issues**:

- #68

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary
- Review online by looking at the diff
- Trigger the workflow manually via the GitHub Actions tab (button should appear after merge)

