### PR TITLE
Remove license section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,3 @@ url: https://github.com/apardyl/cudaplusplus
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for a guide on how to contribute and [README.dev.md](README.dev.md) for documentation on setting up your development environment.
-
-## License
-
-This code is licensed under Apache 2.0. Copyright is with John Romein, Netherlands Institute for Radio Astronomy (ASTRON).


### PR DESCRIPTION
**Description**

This PR removes the License section from the main `README.md`, since we already have a `LICENSE` file and a `CITATION.cff` file (both recognized by GitHub frontend/metadata, as well as Zenodo when a release is made).

![image](https://user-images.githubusercontent.com/4558105/156184652-9ef7cfd4-66d6-436e-929b-e35677f581ba.png)


**Related issues**:

- #11

**Instructions to review the pull request**

- Check that CHANGELOG.md has been updated if necessary

Review online by checking the bottom of the README on this branch.

